### PR TITLE
basemap: fix arabic and RTL text display by loading plugin from unpkg

### DIFF
--- a/src/components/map-viewer.vue
+++ b/src/components/map-viewer.vue
@@ -123,6 +123,7 @@ export default {
         opts.zoom = this.zoom
       }
 
+      maplibre.setRTLTextPlugin("https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js")
       this.map = new maplibre.Map(opts)
       this.map.addControl(new maplibre.FullscreenControl())
       this.map.addControl(new maplibre.NavigationControl())


### PR DESCRIPTION
Grab the plugin from the unpkg CDN. It does bloat the page load but there's no alternative right now. 

(In the near future will offer default-latin labels)