### PR TITLE
Allow free text on taginput

### DIFF
--- a/playground/app/pages/controls/taginput.vue
+++ b/playground/app/pages/controls/taginput.vue
@@ -127,6 +127,20 @@
         </p>
       </t-demo-box>
 
+      <!-- Allow New (Free-form) -->
+      <t-demo-box label="Allow New Tags">
+        <t-taginput
+          v-model="allowNewSelected"
+          :options="fruitOptions"
+          placeholder="Type and press Enter or comma..."
+          allow-new
+          open-on-focus
+        />
+        <p class="has-text-grey mt-3">
+          Type any text and press Enter or comma to add a custom tag. Selected: {{ allowNewSelected }}
+        </p>
+      </t-demo-box>
+
       <!-- Not Closable -->
       <t-demo-box label="Non-closable Tags">
         <t-taginput
@@ -303,6 +317,7 @@ const readonlySelected = ref<string[]>(['apple', 'cherry', 'grape'])
 const maxTagsSelected = ref<string[]>(['apple'])
 const notClosableSelected = ref<string[]>(['apple'])
 const customSelected = ref<number[]>([1, 3])
+const allowNewSelected = ref<string[]>([])
 const searchSelected = ref<string[]>([])
 const searchText = ref('')
 

--- a/src/runtime/controls/taginput.test.ts
+++ b/src/runtime/controls/taginput.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import TTaginput from '../controls/taginput.vue'
+import {
+  mountComponent,
+  triggerKeyboard
+} from '../lib/testutil/component-helpers'
+
+const fruitOptions = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' }
+]
+
+describe('TTaginput allowNew', () => {
+  it('adds a free-form tag on Enter', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('custom')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    const emitted = wrapper.emitted('update:modelValue') as string[][]
+    expect(emitted[emitted.length - 1]).toEqual([['custom']])
+  })
+
+  it('adds a free-form tag on separator key', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('newtag')
+    await triggerKeyboard(wrapper, ',', 'input')
+    const emitted = wrapper.emitted('update:modelValue') as string[][]
+    expect(emitted[emitted.length - 1]).toEqual([['newtag']])
+  })
+
+  it('does not add free-form tag when allowNew is false', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: false }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('custom')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('does not add duplicate tags', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: ['existing'], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('existing')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    // Should clear input but not emit a new modelValue with duplicate
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('respects maxTags limit', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: ['a', 'b'], options: fruitOptions, allowNew: true, maxTags: 2 }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('third')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('trims whitespace from new tags', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('  spaced  ')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    const emitted = wrapper.emitted('update:modelValue') as string[][]
+    expect(emitted[emitted.length - 1]).toEqual([['spaced']])
+  })
+
+  it('does not add empty tags', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('   ')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('selects dropdown option over free-form when highlighted', async () => {
+    const wrapper = mountComponent(TTaginput, {
+      props: { modelValue: [], options: fruitOptions, allowNew: true }
+    })
+    const input = wrapper.find('input')
+    await input.setValue('a') // filters to Apple
+    // Arrow down to highlight first option, then Enter
+    await triggerKeyboard(wrapper, 'ArrowDown', 'input')
+    await triggerKeyboard(wrapper, 'Enter', 'input')
+    const emitted = wrapper.emitted('update:modelValue') as string[][]
+    expect(emitted[emitted.length - 1]).toEqual([['apple']])
+  })
+})

--- a/src/runtime/controls/taginput.vue
+++ b/src/runtime/controls/taginput.vue
@@ -170,6 +170,10 @@ const props = withDefaults(defineProps<{
   emptyText?: string
   /** Maximum number of tags that can be selected. When undefined, there is no limit. */
   maxTags?: number
+  /** Allow creating new tags not in the options list. @default false */
+  allowNew?: boolean
+  /** Separator keys that trigger creating a new tag (in addition to Enter). @default [','] */
+  separators?: string[]
 }>(), {
   options: () => [],
   placeholder: '',
@@ -184,7 +188,9 @@ const props = withDefaults(defineProps<{
   closable: true,
   rounded: false,
   emptyText: 'None selected',
-  maxTags: undefined
+  maxTags: undefined,
+  allowNew: false,
+  separators: () => [',']
 })
 
 const emit = defineEmits<{
@@ -339,6 +345,13 @@ function handleBlur () {
 function handleKeydown (event: KeyboardEvent) {
   if (props.readonly) return
 
+  // Handle separator keys (e.g. comma) for creating new tags
+  if (props.allowNew && props.separators.includes(event.key)) {
+    event.preventDefault()
+    addNewTag()
+    return
+  }
+
   switch (event.key) {
     case 'ArrowDown':
       event.preventDefault()
@@ -361,6 +374,8 @@ function handleKeydown (event: KeyboardEvent) {
         if (option) {
           selectOption(option)
         }
+      } else {
+        addNewTag()
       }
       break
     case 'Escape':
@@ -376,6 +391,23 @@ function handleKeydown (event: KeyboardEvent) {
       }
       break
   }
+}
+
+function addNewTag () {
+  const text = searchText.value.trim()
+  if (!text || !props.allowNew || isMaxReached.value) return false
+  // Check if it already exists as a selected value
+  if (modelValue.value.includes(text as T)) {
+    searchText.value = ''
+    return true
+  }
+  const option: TagOption = { value: text as T, label: text }
+  modelValue.value = [...modelValue.value, text as T]
+  emit('select', option)
+  searchText.value = ''
+  highlightedIndex.value = -1
+  inputRef.value?.focus()
+  return true
 }
 
 function selectOption (option: TagOption) {

--- a/src/runtime/controls/taginput.vue
+++ b/src/runtime/controls/taginput.vue
@@ -170,7 +170,7 @@ const props = withDefaults(defineProps<{
   emptyText?: string
   /** Maximum number of tags that can be selected. When undefined, there is no limit. */
   maxTags?: number
-  /** Allow creating new tags not in the options list. @default false */
+  /** Allow creating new tags not in the options list. Only for string-typed taginputs. @default false */
   allowNew?: boolean
   /** Separator keys that trigger creating a new tag (in addition to Enter). @default [','] */
   separators?: string[]
@@ -345,13 +345,6 @@ function handleBlur () {
 function handleKeydown (event: KeyboardEvent) {
   if (props.readonly) return
 
-  // Handle separator keys (e.g. comma) for creating new tags
-  if (props.allowNew && props.separators.includes(event.key)) {
-    event.preventDefault()
-    addNewTag()
-    return
-  }
-
   switch (event.key) {
     case 'ArrowDown':
       event.preventDefault()
@@ -388,6 +381,12 @@ function handleKeydown (event: KeyboardEvent) {
         if (lastTag) {
           removeTag(lastTag)
         }
+      }
+      break
+    default:
+      if (props.allowNew && props.separators.includes(event.key)) {
+        event.preventDefault()
+        addNewTag()
       }
       break
   }


### PR DESCRIPTION
## Summary

Add `allowNew` prop to the taginput component, enabling free-form tag creation in addition to selecting from a predefined options list. When enabled, users can type arbitrary text and press Enter or a separator key (comma by default) to create new tags.

### Taginput changes

- New `allowNew` prop (default `false`) — when true, pressing Enter with no dropdown selection or typing a separator key creates a tag from the current input text. Intended for string-typed taginputs only.
- New `separators` prop (default `[',']`) — configurable keys that trigger new tag creation. Handled in the `default` switch case so they cannot override Enter, Escape, Arrow, or Backspace behavior.
- Duplicates are silently ignored, and `maxTags` limit is respected
- Dropdown still works normally: if an option is highlighted, Enter selects it; only falls through to free-form creation when nothing is highlighted

### Playground

- Added "Allow New Tags" demo showing free-form entry with the `allow-new` prop

### Tests

- 8 new jsdom tests covering: Enter/separator tag creation, allowNew disabled, duplicate rejection, maxTags limit, whitespace trimming, empty input rejection, and dropdown selection priority over free-form

## Test plan

- Navigate to the taginput playground page
- In the "Allow New Tags" demo, type a custom string and press Enter — verify it appears as a tag
- Type text followed by a comma — verify the tag is created and the comma is not included
- Type a duplicate value — verify it is not added again
- Verify selecting from the dropdown still works as before in all other demos

🤖 Generated with [Claude Code](https://claude.com/claude-code)