### PR TITLE
Add "Imported or edited" column to Station Editor stops list

### DIFF
--- a/src/runtime/apps/stations/stop-table.vue
+++ b/src/runtime/apps/stations/stop-table.vue
@@ -25,8 +25,8 @@
               </td>
               <td><tl-safelink :text="stop.stop_id" max-width="100px" /></td>
               <td>{{ servedByRoutes(stop) }}</td>
-              <td :title="absoluteTime(stop.updated_at)">
-                {{ relativeTime(stop.updated_at) }}
+              <td :title="absoluteTime(latestUpdatedAt(stop))">
+                {{ relativeTime(latestUpdatedAt(stop)) }}
               </td>
             </tr>
           </tbody>
@@ -46,14 +46,25 @@ import relativeTimePlugin from 'dayjs/plugin/relativeTime'
 dayjs.extend(relativeTimePlugin)
 
 // Types
+interface TimestampedRef {
+  id: number
+  updated_at?: string | null
+}
+
 interface FeedVersionResponse {
   stops: {
     id: number
     stop_id: string
     stop_name: string
     updated_at?: string | null
+    pathways_from_stop?: TimestampedRef[]
+    pathways_to_stop?: TimestampedRef[]
+    child_levels?: TimestampedRef[]
     children?: {
       id: number
+      updated_at?: string | null
+      pathways_from_stop?: TimestampedRef[]
+      pathways_to_stop?: TimestampedRef[]
       route_stops: {
         route: {
           id: number
@@ -116,8 +127,14 @@ const STOPS_QUERY = gql`
         stop_id
         stop_name
         updated_at
+        pathways_from_stop { id updated_at }
+        pathways_to_stop { id updated_at }
+        child_levels { id updated_at }
         children {
           id
+          updated_at
+          pathways_from_stop { id updated_at }
+          pathways_to_stop { id updated_at }
           route_stops {
             route {
               id
@@ -189,6 +206,26 @@ const relativeTime = (value?: string | null): string => {
 const absoluteTime = (value?: string | null): string => {
   if (!value) return ''
   return dayjs(value).format('YYYY-MM-DD HH:mm:ss')
+}
+
+// Roll up updated_at across the station and its constituent records
+// (child platforms, pathways from/to either, levels) so the column
+// reflects the most recent edit to anything in the station.
+const latestUpdatedAt = (stop: Stop): string | null => {
+  let max: string | null = null
+  const consider = (v?: string | null) => {
+    if (v && (!max || v > max)) max = v
+  }
+  consider(stop.updated_at)
+  for (const p of stop.pathways_from_stop || []) consider(p.updated_at)
+  for (const p of stop.pathways_to_stop || []) consider(p.updated_at)
+  for (const l of stop.child_levels || []) consider(l.updated_at)
+  for (const c of stop.children || []) {
+    consider(c.updated_at)
+    for (const p of c.pathways_from_stop || []) consider(p.updated_at)
+    for (const p of c.pathways_to_stop || []) consider(p.updated_at)
+  }
+  return max
 }
 
 const servedByRoutes = (stop: Stop): string => {

--- a/src/runtime/apps/stations/stop-table.vue
+++ b/src/runtime/apps/stations/stop-table.vue
@@ -25,8 +25,10 @@
               </td>
               <td><tl-safelink :text="stop.stop_id" max-width="100px" /></td>
               <td>{{ servedByRoutes(stop) }}</td>
-              <td :title="absoluteTime(latestUpdatedAt(stop))">
-                {{ relativeTime(latestUpdatedAt(stop)) }}
+              <td>
+                <abbr class="abbr" :title="absoluteTime(latestUpdatedAt(stop))">
+                  {{ relativeTime(latestUpdatedAt(stop)) }}
+                </abbr>
               </td>
             </tr>
           </tbody>

--- a/src/runtime/apps/stations/stop-table.vue
+++ b/src/runtime/apps/stations/stop-table.vue
@@ -17,17 +17,17 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="stop of stops" :key="stop.id">
+            <tr v-for="row of displayStops" :key="row.stop.id">
               <td>
-                <slot name="stopName" :stop="stop">
-                  {{ stop.stop_name }}
+                <slot name="stopName" :stop="row.stop">
+                  {{ row.stop.stop_name }}
                 </slot>
               </td>
-              <td><tl-safelink :text="stop.stop_id" max-width="100px" /></td>
-              <td>{{ servedByRoutes(stop) }}</td>
+              <td><tl-safelink :text="row.stop.stop_id" max-width="100px" /></td>
+              <td>{{ servedByRoutes(row.stop) }}</td>
               <td>
-                <abbr class="abbr" :title="absoluteTime(latestUpdatedAt(stop))">
-                  {{ relativeTime(latestUpdatedAt(stop)) }}
+                <abbr v-if="row.absolute" class="abbr" :title="row.absolute">
+                  {{ row.relative }}
                 </abbr>
               </td>
             </tr>
@@ -42,10 +42,8 @@
 import { computed, ref } from 'vue'
 import { gql } from 'graphql-tag'
 import { useQuery } from '@vue/apollo-composable'
-import dayjs from 'dayjs/esm'
-import relativeTimePlugin from 'dayjs/esm/plugin/relativeTime'
-
-dayjs.extend(relativeTimePlugin)
+import { format, parseISO } from 'date-fns'
+import { fromNow } from '../../lib/util/filters'
 
 // Types
 interface TimestampedRef {
@@ -200,23 +198,21 @@ const routeName = (route: Route): string => {
   return ''
 }
 
-const relativeTime = (value?: string | null): string => {
-  if (!value) return ''
-  return dayjs(value).fromNow()
-}
-
-const absoluteTime = (value?: string | null): string => {
-  if (!value) return ''
-  return dayjs(value).format('YYYY-MM-DD HH:mm:ss')
-}
-
 // Roll up updated_at across the station and its constituent records
 // (child platforms, pathways from/to either, levels) so the column
-// reflects the most recent edit to anything in the station.
+// reflects the most recent edit to anything in the station. The API
+// returns naive timestamps treated as UTC (matches lib/util/filters
+// fromNow convention).
 const latestUpdatedAt = (stop: Stop): string | null => {
-  let max: string | null = null
+  let maxStr: string | null = null
+  let maxMs = Number.NEGATIVE_INFINITY
   const consider = (v?: string | null) => {
-    if (v && (!max || v > max)) max = v
+    if (!v) return
+    const ms = parseISO(v + 'Z').getTime()
+    if (Number.isFinite(ms) && ms > maxMs) {
+      maxMs = ms
+      maxStr = v
+    }
   }
   consider(stop.updated_at)
   for (const p of stop.pathways_from_stop || []) consider(p.updated_at)
@@ -227,8 +223,11 @@ const latestUpdatedAt = (stop: Stop): string | null => {
     for (const p of c.pathways_from_stop || []) consider(p.updated_at)
     for (const p of c.pathways_to_stop || []) consider(p.updated_at)
   }
-  return max
+  return maxStr
 }
+
+const absoluteTime = (value: string): string =>
+  format(parseISO(value + 'Z'), 'yyyy-MM-dd HH:mm:ss')
 
 const servedByRoutes = (stop: Stop): string => {
   const routeNames = new Set<string>()
@@ -258,4 +257,21 @@ const stops = computed<Stop[]>(() => {
   }
   return allStops
 })
+
+interface DisplayStop {
+  stop: Stop
+  relative: string
+  absolute: string
+}
+
+const displayStops = computed<DisplayStop[]>(() =>
+  stops.value.map((stop) => {
+    const latest = latestUpdatedAt(stop)
+    return {
+      stop,
+      relative: latest ? fromNow(latest) : '',
+      absolute: latest ? absoluteTime(latest) : ''
+    }
+  })
+)
 </script>

--- a/src/runtime/apps/stations/stop-table.vue
+++ b/src/runtime/apps/stations/stop-table.vue
@@ -40,8 +40,8 @@
 import { computed, ref } from 'vue'
 import { gql } from 'graphql-tag'
 import { useQuery } from '@vue/apollo-composable'
-import dayjs from 'dayjs'
-import relativeTimePlugin from 'dayjs/plugin/relativeTime'
+import dayjs from 'dayjs/esm'
+import relativeTimePlugin from 'dayjs/esm/plugin/relativeTime'
 
 dayjs.extend(relativeTimePlugin)
 

--- a/src/runtime/apps/stations/stop-table.vue
+++ b/src/runtime/apps/stations/stop-table.vue
@@ -13,6 +13,7 @@
               <th>Stop name</th>
               <th>GTFS ID</th>
               <th>Served by routes</th>
+              <th>Imported or edited</th>
             </tr>
           </thead>
           <tbody>
@@ -24,6 +25,9 @@
               </td>
               <td><tl-safelink :text="stop.stop_id" max-width="100px" /></td>
               <td>{{ servedByRoutes(stop) }}</td>
+              <td :title="absoluteTime(stop.updated_at)">
+                {{ relativeTime(stop.updated_at) }}
+              </td>
             </tr>
           </tbody>
         </table>
@@ -36,6 +40,10 @@
 import { computed, ref } from 'vue'
 import { gql } from 'graphql-tag'
 import { useQuery } from '@vue/apollo-composable'
+import dayjs from 'dayjs'
+import relativeTimePlugin from 'dayjs/plugin/relativeTime'
+
+dayjs.extend(relativeTimePlugin)
 
 // Types
 interface FeedVersionResponse {
@@ -43,6 +51,7 @@ interface FeedVersionResponse {
     id: number
     stop_id: string
     stop_name: string
+    updated_at?: string | null
     children?: {
       id: number
       route_stops: {
@@ -106,6 +115,7 @@ const STOPS_QUERY = gql`
         id
         stop_id
         stop_name
+        updated_at
         children {
           id
           route_stops {
@@ -169,6 +179,16 @@ const routeName = (route: Route): string => {
     return route.route_long_name
   }
   return ''
+}
+
+const relativeTime = (value?: string | null): string => {
+  if (!value) return ''
+  return dayjs(value).fromNow()
+}
+
+const absoluteTime = (value?: string | null): string => {
+  if (!value) return ''
+  return dayjs(value).format('YYYY-MM-DD HH:mm:ss')
 }
 
 const servedByRoutes = (stop: Stop): string => {


### PR DESCRIPTION
## Summary

- Adds an "Imported or edited" column to the Station Editor stations list, showing a relative timestamp ("3 days ago") for each row, with the absolute timestamp on hover.
- The displayed time is the **most recent `updated_at` across the station and its constituent records** (child platforms, pathways from/to either, child levels), computed client-side from a single GraphQL query. Editing any pathway, level, or child platform of a station bumps the displayed time on the parent row.
- Uses `dayjs` with the `relativeTime` plugin (already a dependency). Imports from `dayjs/esm/...` so the plugin resolves cleanly under Vite's dev ESM — the default `dayjs/plugin/relativeTime` path is UMD/CJS with no `default` export and fails at dev-server load.

**Depends on:** interline-io/transitland-lib#607 exposing `created_at`/`updated_at` on `Stop`, `Pathway`, and `Level`. Merge after the API has been deployed with that change.

## Test plan

- [ ] Open the Station Editor stations list and confirm the new column renders a relative timestamp for each row.
- [ ] Hover a cell and confirm the tooltip shows an absolute `YYYY-MM-DD HH:mm:ss` timestamp.
- [ ] Edit a child platform of a station; reload the parent stations list; confirm the parent row's timestamp updated.
- [ ] Edit a pathway within a station; reload; confirm the parent row's timestamp updated.
- [ ] Edit a level within a station; reload; confirm the parent row's timestamp updated.
- [ ] Edit the parent station itself; reload; confirm its row's timestamp updated.
- [ ] On a freshly imported feed version where nothing has been edited, confirm rows show the import time (not blank or broken).