### PR TITLE
Add apps opt-out option to allow external app modules

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -31,6 +31,13 @@ export interface ModuleOptions {
   // Transfer Analyst options
   transferAnalystReadOnlyFeedSelector?: boolean
   transferAnalystGtfsRealtimeStopObservations?: boolean
+  // Per-app component registration (default true). Set false to let a consumer
+  // register the app's components from a separate package (e.g. @interline-io/station-editor).
+  apps?: {
+    stations?: boolean
+    transfers?: boolean
+    admin?: boolean
+  }
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -158,10 +165,15 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Add apps (TlApps* components)
+    const appsIgnore: string[] = []
+    if (options.apps?.stations === false) appsIgnore.push('stations/**')
+    if (options.apps?.transfers === false) appsIgnore.push('transfers/**')
+    if (options.apps?.admin === false) appsIgnore.push('admin/**')
     addComponentsDir({
       path: resolveRuntimeModule('apps'),
       pathPrefix: true,
-      prefix: 'TlApps'
+      prefix: 'TlApps',
+      ignore: appsIgnore
     })
 
     // Nuxt 4: Transpile packages for SSR compatibility


### PR DESCRIPTION
## Summary

Adds a granular `apps?: { stations?, transfers?, admin? }` option to `ModuleOptions`. When a flag is set to `false`, the corresponding subdirectory is skipped during the `apps/` component scan via `addComponentsDir`'s `ignore`.

Defaults to scanning all three (`true`), so this is fully backward compatible.

The flag exists so consumers can register a specific app's components from a separate package (e.g. `@interline-io/station-editor` from the `tlv2-apps` monorepo) without colliding with tlv2-ui's `TlApps*` registrations under SSR.

### Why now

`www-transit-land-v2` is migrating its Station Editor from this package to `@interline-io/station-editor`. www has `ssr: true`, so the duplicate `TlAppsStations*` component registrations from both modules need a clean opt-out rather than relying on registration order. Future migrations of Transfer Analyst and Admin apps can reuse the same gate (`apps: { transfers: false }`, `apps: { admin: false }`).

### Behavior

- `apps?.stations === false` → ignores `stations/**` under the `apps/` scan
- `apps?.transfers === false` → ignores `transfers/**`
- `apps?.admin === false` → ignores `admin/**`
- Anything else (including unset and `true`) keeps current behavior

The `./apps/stations` subpath export in `package.json` is left in place — harmless to keep until every consumer has migrated.

## Test plan

- Existing playground / dev still registers all `TlApps*` components without changes
- Smoke-test in www-transit-land-v2's PR: with `tlv2: { apps: { stations: false } }` set, no `TlAppsStations*` are registered by tlv2-ui, and `@interline-io/station-editor` provides them instead with no `[Vue warn]` for duplicate component names